### PR TITLE
Only trigger retry if not abort

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.js",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "readmeFilename": "README.md",
   "description": "VTEX JS SDK",
   "deploy": "deploy/",

--- a/src/retry-ajax.coffee
+++ b/src/retry-ajax.coffee
@@ -23,7 +23,7 @@ pipeFailRetry = (jqXHR, opts) ->
     # whenever we do make this request, pipe its output to our deferred
 
     nextRequest = ->
-      $(window).trigger(events.RETRY)
+      $(window).trigger(events.RETRY, input)
       $.ajax(ajaxOptions).retry(
         times: times - 1
         timeout: opts.timeout
@@ -48,7 +48,8 @@ pipeFailRetry = (jqXHR, opts) ->
       else
         nextRequest()
     else
-      $(window).trigger(events.FAIL_RETRY, input)
+      if (input.statusText isnt 'abort' or jqXHR.statusText isnt 'abort')
+        $(window).trigger(events.FAIL_RETRY, input)
       # no times left, reject our deferred with the current arguments
       output.rejectWith this, arguments
     output


### PR DESCRIPTION
Ignorar um request falho, caso a causa da falha tenha sido um `abort`

Ás vezes ocorre de ter dois requests para `shippingData` consecutivos, e o primeiro ser abortado. Esse request não pode ser contado como um `retry` na métrica.
