### PR TITLE
CHK-846: Trigger attachmentUpdated event on sendAttachment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.13.0] - 2021-09-16
 ### Added
 - Event `attachmentUpdated.vtex` for when an attachment is updated by using the 
   `sendAttachment` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Event `attachmentUpdated.vtex` for when an attachment is updated by using the 
+  `sendAttachment` method.
 
 ## [2.12.0] - 2021-04-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.js",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "readmeFilename": "README.md",
   "description": "VTEX JS SDK",
   "deploy": "deploy/",

--- a/src/checkout.coffee
+++ b/src/checkout.coffee
@@ -34,6 +34,7 @@ class Checkout
 
   events =
     ORDER_FORM_UPDATED: 'orderFormUpdated.vtex'
+    ATTACHMENT_UPDATED: 'attachmentUpdated.vtex'
     REQUEST_BEGIN: 'checkoutRequestBegin.vtex'
     REQUEST_END: 'checkoutRequestEnd.vtex'
 
@@ -155,9 +156,13 @@ class Checkout
 
     attachment['expectedOrderFormSections'] = expectedOrderFormSections
 
-    @_updateOrderForm
+    xhr = @_updateOrderForm
       url: @_getSaveAttachmentURL(attachmentId)
       data: JSON.stringify(attachment)
+
+    xhr.done((orderForm) =>
+      $(window).trigger(events.ATTACHMENT_UPDATED, [attachmentId, orderForm])
+    )
 
   # Sends a request to set the used locale.
   sendLocale: (locale='pt-BR') =>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Triggers a new event `attachmentUpdated.vtex` when an attachment is updated with the `sendAttachment method`

#### What problem is this solving?

This will enable us to listen for events on specific updates to attachments, which will be useful for us to implement the update on the address form UI when the invoice address is updated for example.

#### How should this be manually tested?

First, you need to run this repository with `yarn grunt`, then run `vcs.checkout-ui` with `yarn grunt --link=vtex.js`.

After that, you should be able to paste the following in your browser's devtools console:

```js
$(window).on('attachmentUpdated.vtex', (_, attachmentId, orderForm) => {
  console.log({ attachmentId, orderForm })
})
```

And then interect with checkout as you would. You will be able to see the above log for every action that updates one of the attachments.

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
