### PR TITLE
Remove broken cookie on checkout script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove broken cookie affecting Checkout's cookie.
 
 ## [2.13.0] - 2021-09-16
 ### Added

--- a/src/checkout.coffee
+++ b/src/checkout.coffee
@@ -583,5 +583,9 @@ window.vtexjs or= {}
 window.vtexjs.Checkout = Checkout
 window.vtexjs.checkout = new window.vtexjs.Checkout()
 
+# Temporary script for cleaning a malformed cookie caused by a third party script.
 if typeof document != 'undefined'
-	document.cookie = '[object Object]=; path=/; Max-Age=-99999999;'
+	try
+		document.cookie = '[object Object]=; path=/; Max-Age=-99999999;'
+	catch err
+		console.error 'Error while cleaning cookie', err

--- a/src/checkout.coffee
+++ b/src/checkout.coffee
@@ -582,3 +582,6 @@ class Checkout
 window.vtexjs or= {}
 window.vtexjs.Checkout = Checkout
 window.vtexjs.checkout = new window.vtexjs.Checkout()
+
+if typeof document != 'undefined'
+	document.cookie = '[object Object]=; path=/; Max-Age=-99999999;'


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR removes the cookie with the name `[Object object]`, which affected the cart cookie on Checkout API.

#### What problem is this solving?

The cookie has invalid characters that the .NET Framework can't parse, and because of this the API can't read the cart cookie if this other cookie is present in the request headers.

#### How should this be manually tested?

N/A

#### Screenshots or example usage

N/A

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
