### PR TITLE
[CHK-3829]: Add custom checkout user agent header

### DIFF
--- a/.vtex/deployment.json
+++ b/.vtex/deployment.json
@@ -5,7 +5,7 @@
     "description": "",
     "build": {
       "provider": "jenkins",
-      "type": "grunt-frontend",
+      "type": "frontend",
       "parameters": {
         "AWS_ACCOUNT_ID": "053131491888",
         "AWS_REGION": "us-east-1",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Custom checkout user agent header to `getOrderForm` calls.
+
 ## [2.13.0] - 2021-09-16
 ### Added
 - Event `attachmentUpdated.vtex` for when an attachment is updated by using the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.1] - 2024-06-05
+
 ### Added
 - Custom checkout user agent header to `getOrderForm` calls.
 
@@ -44,3 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Finish transaction method with new gateway callback endpoint which receives an orderGroupId
+
+
+[Unreleased]: https://github.com/vtex/vtex.js/compare/v2.13.1...HEAD
+[2.13.1]: https://github.com/vtex/vtex.js/compare/v2.13.0...v2.13.1

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-shell": "^0.7.0",
     "grunt-vtex": "^0.16.0",
-    "jasmine": "^3.2.0",
-    "jasmine-node": "^2.0.1",
     "jest": "^22.4.4",
     "jquery": "^3.3.1",
     "jquery-mockjax": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.js",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "readmeFilename": "README.md",
   "description": "VTEX JS SDK",
   "deploy": "deploy/",

--- a/spec/checkout-spec.coffee
+++ b/spec/checkout-spec.coffee
@@ -1,7 +1,6 @@
 $ = require 'jquery'
 window.$ = $
 AjaxQueue = require '../src/extended-ajax'
-jasmine = require 'jasmine'
 mockjax = require 'jquery-mockjax'
 mockjax = mockjax($, window)
 {mock, API_URL, SIMULATION_URL, GATEWAY_URL} = require './mock/checkout-mock.coffee'

--- a/src/checkout.coffee
+++ b/src/checkout.coffee
@@ -143,6 +143,9 @@ class Checkout
         contentType: 'application/json; charset=utf-8'
         dataType: 'json'
         data: JSON.stringify(checkoutRequest)
+        beforeSend: (xhr) ->
+          if(window.vtex?.checkout?.version)
+            xhr.setRequestHeader('Checkout-User-Agent', 'legacy@' + window.vtex.checkout.version)
 
       xhr.done(@_cacheOrderForm)
       xhr.done(@_broadcastOrderFormUnlessPendingRequests)


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

ATTS

We need that to create some Checkout KPIs.

#### How should this be manually tested?

- `yarn build`
- Run `vcs.checkout-ui`'s `master` branch with `yarn grunt --link=vtex.js`
- Access http://vtexgame1.vtexlocal.com.br/checkout
- Open dev tools
- Look for the `getOrderForm` request 
- Check for a `Checkout-User-Agent` header


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
